### PR TITLE
fix RecursionError on windows

### DIFF
--- a/ontoenv/__init__.py
+++ b/ontoenv/__init__.py
@@ -241,7 +241,7 @@ def find_root_file(start=None) -> Optional[Path]:
             raise Exception(f".ontoenv ({oe_dir}) must be a directory")
         return oe_dir
 
-    if str(start) == start.root:
+    if len(start.parts) == 1:
         return None
 
     return find_root_file(start.parent)


### PR DESCRIPTION
WindowsPath('c:/sdfsd/asdf/sf').root = '//' (not c:)