### PR TITLE
use cli from module invocation

### DIFF
--- a/ontoenv/cli.py
+++ b/ontoenv/cli.py
@@ -56,3 +56,7 @@ def output(output_filename):
 def deps(root_uri):
     oe = OntoEnv(initialize=False)
     oe.print_dependency_graph(root_uri)
+
+
+if __name__ == '__main__':
+    i()


### PR DESCRIPTION
helps with debugging since you can attach pdb from comman line invocations: python -m pdb -m ontoenv.cli.
