### PR TITLE
Onto getting

### DIFF
--- a/ontoenv/cli.py
+++ b/ontoenv/cli.py
@@ -49,3 +49,6 @@ def deps(root_uri):
     oe = OntoEnv(initialize=False)
     oe.print_dependency_graph(root_uri)
 
+
+if __name__ == '__main__':
+    i()

--- a/ontoenv/cli.py
+++ b/ontoenv/cli.py
@@ -58,5 +58,18 @@ def deps(root_uri):
     oe.print_dependency_graph(root_uri)
 
 
+@i.command(help="Import dependencies in graph")
+@click.argument("in_graph",)# help="Graph with owl imports")
+@click.option("-o", default="imported.ttl",)# help="Graph with imported ontologies")
+@click.option("-s",  is_flag=True, help="Strict mode (error on missing ontologies)",)
+def import_deps(in_graph, o, s):
+    oe = OntoEnv(initialize=False, strict=s)
+    import rdflib
+    g = rdflib.Graph()
+    g.parse(in_graph)
+    oe.import_dependencies(g)
+    g.serialize(o, format='ttl')
+
+
 if __name__ == '__main__':
     i()


### PR DESCRIPTION
In order:
* If the extention is unknown (eg https://brickschema.org/schema/1.3/Brick), try to parse as ttl. Then try xml, ...etc. This should be fixed in graphlib.graph.parse. Also, you have to reinitiate a (new) graph with every try because rdflib goes ahead and shoves incorrectly parsed data into the graph which spills into the next try.
* Use hashes instead of naming (the naming is already in the mapping anyways). I had illegal filename characters otherwise.
* It shouldn't go into .ontoenv to find ontology files. Otherwise, with each refresh, it adds cached ontos as new ontos (as 'actual' ontoogies).
